### PR TITLE
Missing permission access check on view form

### DIFF
--- a/src/views/form/components/formgenerator/info.blade.php
+++ b/src/views/form/components/formgenerator/info.blade.php
@@ -14,7 +14,9 @@
                 <div class="form-actions top">
                     <div class="btn-set pull-right">
                        {!! form_widget($form->back) !!}
+                        @if(PermissionUtil::hasAccess($route.'getEdit'))
                            <a href="{{ action($route.'getEdit',$id) }}" class="btn btn-sm yellow filter-submit margin-bottom"><i class="glyphicon glyphicon-edit"></i> {{trans('form-builder::form.edit')}}</a>
+                        @endif
                     </div>
                 </div>
                 <div class="form-horizontal form-bordered">
@@ -23,7 +25,9 @@
                 <div class="form-actions ">
                     <div class="btn-set pull-right">
                        {!! form_widget($form->back) !!}
+                        @if(PermissionUtil::hasAccess($route.'getEdit'))
                           <a href="{{ action($route.'getEdit',$id) }}" class="btn btn-sm yellow filter-submit margin-bottom"><i class="glyphicon glyphicon-edit"></i> {{trans('form-builder::form.edit')}}</a>
+                        @endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
One permission access check is missing on the blade "info" (read-only view).
The "edit" button shouldnt be displayed if the connected user doesn't have the related permission.