### PR TITLE
:pencil: :bug: Fixed last moxie manager allowed extension not working

### DIFF
--- a/src/views/form/partial/upload.blade.php
+++ b/src/views/form/partial/upload.blade.php
@@ -22,7 +22,7 @@
                                       class="btn blue"
                                       onclick="moxman.browse({
                                       @if(!empty($options['extensions']))
-                                              extensions: '{{$options['extensions']}} ',
+                                              extensions: '{{$options['extensions']}}',
                                       @endif
                                       @if(!empty($options['view']))
                                               view: '{{$options['view']}}',


### PR DESCRIPTION
The space before the end quote made the last allowed extension not working.
Example : extensions:  'jpg,png,jpeg ' => moxie manager allowed 'jpeg ' (including the space) but not 'jpeg' (no space)